### PR TITLE
Fix makefile

### DIFF
--- a/Tortoise.csproj
+++ b/Tortoise.csproj
@@ -7,4 +7,11 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
+  <Target Name="Rename" AfterTargets="Publish" Condition="'$(ExecutableName)'!='' and '$(ExecutableName)'!='$(AssemblyName)'">
+    <Message Text="Attempting to rename executable file from $(PublishDir)/$(AssemblyName) to $(PublishDir)/$(ExecutableName)" Importance="high" />
+    <Move SourceFiles="$(PublishDir)/$(AssemblyName)" DestinationFiles="$(PublishDir)/$(ExecutableName)" ContinueOnError="true" />
+    <Message Text="Attempting to rename executable file from $(PublishDir)\$(AssemblyName).exe to $(PublishDir)/$(ExecutableName).exe" Importance="high" />
+    <Move SourceFiles="$(PublishDir)/$(AssemblyName).exe" DestinationFiles="$(PublishDir)/$(ExecutableName).exe" ContinueOnError="true" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Add makefile ready to work with OpenBench, based on the one I'm using in Lynx.
It creates a single-file, self-contained binary of Tortoise.

Tested in Windows and Linux using:
- `make`
- `make EXE=tortoise-test`